### PR TITLE
add `--preserve-extensions` option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -11,9 +11,13 @@ const cli = cac("@atomico/exports").version("1.11.0");
 
 cli.command("<...files>", "Build files")
     .option("--dist <dist>", "Destination directory")
-    .option("--main <dist>", "Nain file")
+    .option("--main <dist>", "Main file")
     .option("--watch", "watch mode")
     .option("--wrappers", "enable the wrapper generator")
+    .option(
+        "--preserve-extensions",
+        "preserve file extensions in exports, for broader ESM compatibility"
+    )
     .option("--ignore-types", "enable the wrapper generator")
     .option("--workspaces", "enable dependency merging")
     .option(
@@ -35,8 +39,10 @@ cli.command("<...files>", "Build files")
          * @param {string[]} src
          * @param {object} flags
          * @param {boolean} flags.watch
+         * @param {string} flags.dist
          * @param {string} flags.main
-         * @param {string} flags.wrappers
+         * @param {boolean} flags.wrappers
+         * @param {boolean} flags.preserveExtensions
          * @param {boolean} flags.tmp
          * @param {boolean} flags.workspaces
          * @param {boolean} flags.publish
@@ -49,6 +55,7 @@ cli.command("<...files>", "Build files")
             {
                 watch,
                 main = "index",
+                preserveExtensions,
                 wrappers,
                 dist,
                 tmp,
@@ -66,6 +73,7 @@ cli.command("<...files>", "Build files")
                     src,
                     main,
                     wrappers,
+                    preserveExtensions,
                     dist,
                     pkg: {
                         src: tmp

--- a/src/create-exports.js
+++ b/src/create-exports.js
@@ -50,6 +50,7 @@ export async function createExports(options) {
               input: filesJs,
               scope: options.pkg.name,
               dist: options.dist,
+              preserveExtensions: options.preserveExtensions,
               centralizeWrappers: options.centralizeWrappers,
               main,
           })

--- a/src/create-wrapper.js
+++ b/src/create-wrapper.js
@@ -23,6 +23,7 @@ export const peerDependencies = [
  * @param {[string,string][]} options.input
  * @param {string} [options.dist]
  * @param {string} [options.main]
+ * @param {boolean} [options.preserveExtensions]
  * @param {boolean} [options.centralizeWrappers]
  * @returns {ReturnType<typeof createWrapper>}
  */
@@ -35,6 +36,7 @@ export async function createWrappers(options) {
                 createWrapper({
                     scope: options.scope,
                     main: options.main,
+                    preserveExtensions: options.preserveExtensions,
                     input,
                     path,
                     dist,
@@ -78,6 +80,7 @@ export async function createWrappers(options) {
  * @param {string} options.path
  * @param {string} options.dist
  * @param {string} options.main
+ * @param {boolean} options.preserveExtensions
  */
 export async function createWrapper(options) {
     const code = await readFile(options.input, "utf8");
@@ -148,10 +151,16 @@ export async function createWrapper(options) {
     if (!elements.length) return;
 
     const imports = elements.map(([name]) => `${name} as _${name}`);
+    const subPath =
+        origin === options.main || !origin
+            ? ""
+            : options.preserveExtensions
+            ? `/${origin}.js`
+            : `/${origin}`;
 
     const originModule = `import { ${imports.join(", ")} } from "${
         options.scope
-    }${origin === options.main || !origin ? "" : "/" + origin}";`;
+    }${subPath}";`;
 
     const tagNames = elements.map(
         ([name, { tagName }]) =>

--- a/src/merge-exports.js
+++ b/src/merge-exports.js
@@ -115,30 +115,6 @@ export async function mergeExports(options) {
         logger(`${result.wrappers.length} wrappers created`);
     }
 
-    if (options.preserveExtensions) {
-        const mappedExports = {};
-        const mappedTypes = {};
-
-        for (const key in result.pkg.exports) {
-            const value = result.pkg.exports[key];
-            const k =
-                extname(value.default) === ".js" && key !== "."
-                    ? `${key}.js`
-                    : key;
-
-            mappedExports[k] = value;
-        }
-
-        for (const key in result.pkg.typesVersions["*"]) {
-            mappedTypes[`${key}.js`] = result.pkg.typesVersions["*"][key];
-        }
-
-        result.pkg.exports = mappedExports;
-        result.pkg.typesVersions["*"] = mappedTypes;
-
-        logger(`extensions preserved`);
-    }
-
     if (options.pkg?.src) {
         logger(`${pkg.name} updating...`);
         const format = getJsonFormat(options.pkg?.snap);

--- a/tests/extensions-dist/module/package.json
+++ b/tests/extensions-dist/module/package.json
@@ -1,0 +1,75 @@
+{
+    "name": "demo",
+    "dependencies": {
+        "atomico": "latest"
+    },
+    "peerDependencies": {
+        "@atomico/react": "*",
+        "@atomico/vue": "*"
+    },
+    "peerDependenciesMeta": {
+        "@atomico/react": {
+            "optional": true
+        },
+        "@atomico/vue": {
+            "optional": true
+        }
+    },
+    "main": "./tests/module/atomico.js",
+    "module": "./tests/module/atomico.js",
+    "types": "./tests/module/atomico.d.ts",
+    "exports": {
+        "./atomico.js": {
+            "types": "./tests/module/atomico.d.ts",
+            "default": "./tests/module/atomico.js"
+        },
+        "./components/a.js": {
+            "default": "./tests/module/components/a/a.js"
+        },
+        "./components/b.js": {
+            "default": "./tests/module/components/b/b.js"
+        },
+        "./components/c.js": {
+            "types": "./tests/module/components/c/c.d.ts",
+            "default": "./tests/module/components/c/c.js"
+        },
+        "./react.js": {
+            "types": "./tests/extensions-dist/module/react.d.ts",
+            "default": "./tests/extensions-dist/module/react.js"
+        },
+        "./preact.js": {
+            "types": "./tests/extensions-dist/module/preact.d.ts",
+            "default": "./tests/extensions-dist/module/preact.js"
+        },
+        "./vue.js": {
+            "types": "./tests/extensions-dist/module/vue.d.ts",
+            "default": "./tests/extensions-dist/module/vue.js"
+        },
+        ".": {
+            "types": "./tests/module/atomico.d.ts",
+            "default": "./tests/module/atomico.js"
+        },
+        "./package.json": {
+            "default": "./tests/module/package.json"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "atomico.js": [
+                "./tests/module/atomico.d.ts"
+            ],
+            "components/c.js": [
+                "./tests/module/components/c/c.d.ts"
+            ],
+            "react.js": [
+                "./tests/extensions-dist/module/react.d.ts"
+            ],
+            "preact.js": [
+                "./tests/extensions-dist/module/preact.d.ts"
+            ],
+            "vue.js": [
+                "./tests/extensions-dist/module/vue.d.ts"
+            ]
+        }
+    }
+}

--- a/tests/extensions-dist/module/preact.d.ts
+++ b/tests/extensions-dist/module/preact.d.ts
@@ -1,0 +1,8 @@
+import { MyComponent as _MyComponent } from "demo";
+import { Component } from "@atomico/react/preact";
+export const MyComponent: Component<typeof _MyComponent>;
+declare namespace JSX {
+   interface IntrinsicElements{
+      "my-component": Component<typeof _MyComponent>;
+   }
+}

--- a/tests/extensions-dist/module/preact.js
+++ b/tests/extensions-dist/module/preact.js
@@ -1,0 +1,4 @@
+"use client";
+import { MyComponent as _MyComponent } from "demo";
+import { auto } from "@atomico/react/preact";
+export const MyComponent = auto(_MyComponent);

--- a/tests/extensions-dist/module/react.d.ts
+++ b/tests/extensions-dist/module/react.d.ts
@@ -1,0 +1,8 @@
+import { MyComponent as _MyComponent } from "demo";
+import { Component } from "@atomico/react";
+export const MyComponent: Component<typeof _MyComponent>;
+declare namespace JSX {
+   interface IntrinsicElements{
+      "my-component": Component<typeof _MyComponent>;
+   }
+}

--- a/tests/extensions-dist/module/react.js
+++ b/tests/extensions-dist/module/react.js
@@ -1,0 +1,4 @@
+"use client";
+import { MyComponent as _MyComponent } from "demo";
+import { auto } from "@atomico/react";
+export const MyComponent = auto(_MyComponent);

--- a/tests/extensions-dist/module/vue.d.ts
+++ b/tests/extensions-dist/module/vue.d.ts
@@ -1,0 +1,3 @@
+import { MyComponent as _MyComponent } from "demo";
+import { Component } from "@atomico/vue";
+export const MyComponent: Component<typeof _MyComponent>;

--- a/tests/extensions-dist/module/vue.js
+++ b/tests/extensions-dist/module/vue.js
@@ -1,0 +1,4 @@
+"use client";
+import { MyComponent as _MyComponent } from "demo";
+import { auto } from "@atomico/vue";
+export const MyComponent = auto(_MyComponent);

--- a/tests/extensions-expect/module/package.json
+++ b/tests/extensions-expect/module/package.json
@@ -1,0 +1,75 @@
+{
+    "name": "demo",
+    "dependencies": {
+        "atomico": "latest"
+    },
+    "peerDependencies": {
+        "@atomico/react": "*",
+        "@atomico/vue": "*"
+    },
+    "peerDependenciesMeta": {
+        "@atomico/react": {
+            "optional": true
+        },
+        "@atomico/vue": {
+            "optional": true
+        }
+    },
+    "main": "./tests/module/atomico.js",
+    "module": "./tests/module/atomico.js",
+    "types": "./tests/module/atomico.d.ts",
+    "exports": {
+        "./atomico.js": {
+            "types": "./tests/module/atomico.d.ts",
+            "default": "./tests/module/atomico.js"
+        },
+        "./components/a.js": {
+            "default": "./tests/module/components/a/a.js"
+        },
+        "./components/b.js": {
+            "default": "./tests/module/components/b/b.js"
+        },
+        "./components/c.js": {
+            "types": "./tests/module/components/c/c.d.ts",
+            "default": "./tests/module/components/c/c.js"
+        },
+        "./react.js": {
+            "types": "./tests/extensions-dist/module/react.d.ts",
+            "default": "./tests/extensions-dist/module/react.js"
+        },
+        "./preact.js": {
+            "types": "./tests/extensions-dist/module/preact.d.ts",
+            "default": "./tests/extensions-dist/module/preact.js"
+        },
+        "./vue.js": {
+            "types": "./tests/extensions-dist/module/vue.d.ts",
+            "default": "./tests/extensions-dist/module/vue.js"
+        },
+        ".": {
+            "types": "./tests/module/atomico.d.ts",
+            "default": "./tests/module/atomico.js"
+        },
+        "./package.json": {
+            "default": "./tests/module/package.json"
+        }
+    },
+    "typesVersions": {
+        "*": {
+            "atomico.js": [
+                "./tests/module/atomico.d.ts"
+            ],
+            "components/c.js": [
+                "./tests/module/components/c/c.d.ts"
+            ],
+            "react.js": [
+                "./tests/extensions-dist/module/react.d.ts"
+            ],
+            "preact.js": [
+                "./tests/extensions-dist/module/preact.d.ts"
+            ],
+            "vue.js": [
+                "./tests/extensions-dist/module/vue.d.ts"
+            ]
+        }
+    }
+}

--- a/tests/extensions-expect/module/preact.d.ts
+++ b/tests/extensions-expect/module/preact.d.ts
@@ -1,0 +1,8 @@
+import { MyComponent as _MyComponent } from "demo";
+import { Component } from "@atomico/react/preact";
+export const MyComponent: Component<typeof _MyComponent>;
+declare namespace JSX {
+   interface IntrinsicElements{
+      "my-component": Component<typeof _MyComponent>;
+   }
+}

--- a/tests/extensions-expect/module/preact.js
+++ b/tests/extensions-expect/module/preact.js
@@ -1,0 +1,4 @@
+"use client";
+import { MyComponent as _MyComponent } from "demo";
+import { auto } from "@atomico/react/preact";
+export const MyComponent = auto(_MyComponent);

--- a/tests/extensions-expect/module/react.d.ts
+++ b/tests/extensions-expect/module/react.d.ts
@@ -1,0 +1,8 @@
+import { MyComponent as _MyComponent } from "demo";
+import { Component } from "@atomico/react";
+export const MyComponent: Component<typeof _MyComponent>;
+declare namespace JSX {
+   interface IntrinsicElements{
+      "my-component": Component<typeof _MyComponent>;
+   }
+}

--- a/tests/extensions-expect/module/react.js
+++ b/tests/extensions-expect/module/react.js
@@ -1,0 +1,4 @@
+"use client";
+import { MyComponent as _MyComponent } from "demo";
+import { auto } from "@atomico/react";
+export const MyComponent = auto(_MyComponent);

--- a/tests/extensions-expect/module/vue.d.ts
+++ b/tests/extensions-expect/module/vue.d.ts
@@ -1,0 +1,3 @@
+import { MyComponent as _MyComponent } from "demo";
+import { Component } from "@atomico/vue";
+export const MyComponent: Component<typeof _MyComponent>;

--- a/tests/extensions-expect/module/vue.js
+++ b/tests/extensions-expect/module/vue.js
@@ -1,0 +1,4 @@
+"use client";
+import { MyComponent as _MyComponent } from "demo";
+import { auto } from "@atomico/vue";
+export const MyComponent = auto(_MyComponent);

--- a/tests/merge-export.test.js
+++ b/tests/merge-export.test.js
@@ -47,3 +47,47 @@ test("module/atomico", async (t) => {
         )
     );
 });
+
+test("module/atomico - preserve extensions", async (t) => {
+    const snapPkg = await readFile("./tests/module/package.json", "utf8");
+
+    await mergeExports({
+        main: "atomico",
+        src: ["./tests/module/**"],
+        dist: "./tests/extensions-dist/module",
+        preserveExtensions: true,
+        wrappers: true,
+        pkg: {
+            src: "./tests/extensions-dist/module/package.json",
+            snap: snapPkg,
+        },
+    });
+
+    const baseExpect = "./tests/extensions-expect";
+
+    const baseDist = "./tests/extensions-dist";
+
+    const filesExpect = await glob(`${baseExpect}/**`);
+
+    const filesDist = (await glob(`${baseDist}/**`)).reduce(
+        (files, file) => ({
+            ...files,
+            [file.replace(baseDist, "")]: file,
+        }),
+        {}
+    );
+
+    await Promise.all(
+        filesExpect.map(async (file) =>
+            t.is(
+                replaceLine(await readFile(file, "utf8")),
+                replaceLine(
+                    await readFile(
+                        filesDist[file.replace(baseExpect, "")],
+                        "utf8"
+                    )
+                )
+            )
+        )
+    );
+});

--- a/types/create-exports.d.ts
+++ b/types/create-exports.d.ts
@@ -4,6 +4,7 @@
  * @param {Pkg} options.pkg
  * @param {string} [options.main]
  * @param {string} [options.dist]
+ * @param {boolean} [options.preserveExtensions]
  * @param {boolean} [options.wrappers]
  * @param {boolean} [options.ignoreTypes]
  * @param {boolean} [options.centralizePackages]
@@ -15,6 +16,7 @@ export function createExports(options: {
     pkg: Pkg;
     main?: string;
     dist?: string;
+    preserveExtensions?: boolean;
     wrappers?: boolean;
     ignoreTypes?: boolean;
     centralizePackages?: boolean;

--- a/types/merge-exports.d.ts
+++ b/types/merge-exports.d.ts
@@ -3,6 +3,7 @@
  * @param {string[]} options.src
  * @param {string} options.main
  * @param {string} options.dist
+ * @param {boolean} options.preserveExtensions
  * @param {boolean} options.wrappers
  * @param {boolean} options.workspaces
  * @param {boolean} [options.publish]
@@ -16,6 +17,7 @@ export function mergeExports(options: {
     src: string[];
     main: string;
     dist: string;
+    preserveExtensions: boolean;
     wrappers: boolean;
     workspaces: boolean;
     publish?: boolean;

--- a/types/merge-exports.d.ts
+++ b/types/merge-exports.d.ts
@@ -11,7 +11,7 @@
  * @param {boolean} [options.ignoreTypes]
  * @param {boolean} [options.centralizePackages]
  * @param {boolean} [options.centralizeWrappers]
- * @param {{src: string, snap: import("./create-exports").Pkg}} options.pkg
+ * @param {{src: string, snap: string}} options.pkg
  */
 export function mergeExports(options: {
     src: string[];
@@ -27,6 +27,6 @@ export function mergeExports(options: {
     centralizeWrappers?: boolean;
     pkg: {
         src: string;
-        snap: import("./create-exports").Pkg;
+        snap: string;
     };
 }): Promise<void>;


### PR DESCRIPTION
* added option `--present-extensions` which keeps `.js` extensions
  * handles `exports`
  * handles `typesVersions`
  * handles wrappers
* add test
* fixed up some jsdoc types which were incorrect
* small typo fix "nain" -> "main"
